### PR TITLE
RefractiveIndex: arbitrary function for rix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dist
 build
 .idea
+.DS_Store
+

--- a/EMpy/materials.py
+++ b/EMpy/materials.py
@@ -43,8 +43,8 @@ class RefractiveIndex(object):
         Eg. n0_const = 1.448 for SiO2
         
     n0_poly : list/tuple
-        For polynomial rix dispersion function: provide the polynomial coefficients to be evaluated by numpy.polyval.  
-         Eg. `n0_poly = (9,5,3,1)` sets the refractive index function as n = 9(wl**3) + 5(wl**2) + 3(wl) + 1
+        Use a polynomial rix dispersion function: provide the polynomial coefficients to be evaluated by numpy.polyval.  
+         Eg. >>> n0_poly = (9,5,3,1)   # sets the refractive index function as n = 9(wl**3) + 5(wl**2) + 3(wl) + 1
     
     n0_smcoeffs (Sellmeier coefficients): 6-element list/tuple
         Set the rix dispersion function to the 6-parameter Sellmeier function as so:
@@ -52,15 +52,28 @@ class RefractiveIndex(object):
             B1 * wls ** 2 / (wls ** 2 - C1) +
             B2 * wls ** 2 / (wls ** 2 - C2) +
             B3 * wls ** 2 / (wls ** 2 - C3)
-        Eg. `n0_smcoeffs=[B1, B2, B3, C1, C2, C3]`; six values total
-
-    n0_known is only used if RefractiveIndex is evaluated at a single wls.
-        Retrieved as RefractiveIndex.n0_known
+        Eg. >>> n0_smcoeffs = [B1, B2, B3, C1, C2, C3]    # six values total
+    
+    n0_func : function
+        Provide an arbitrary function to return the refractive index versus wavelength.
+        Eg. 
+            >>> SiN_rix = RefractiveIndex(   n0_func = lambda wl: 1.887 + 0.01929/x**2 + 1.6662e-4/x**4   )
+        or
+            >>> def SiN_func(wl):
+            >>>     x = wl * 1e6    # convert to microns
+            >>>     return   1.887 + 0.01929/x**2 + 1.6662e-4/x**4  # cauchy func
+            >>> SiN_rix = RefractiveIndex( n0_func = SiN_func )
+        
+    
+    n0_known : dictionary
+        Use if RefractiveIndex will only evaluated at a specific set of `wls`.
+        n0_known should be a dictionary of key:value == wavelength:rix pairs.
+        Eg. >>> n0_known = { 1599e-9: 1.998,  1550e-9: 1.997,  1600e-9: 1.996 }
 
     """
 
     def __init__(self, n0_const=None, n0_poly=None, n0_smcoeffs=None,
-                 n0_known=None):
+                 n0_known=None, n0_func=None):
         if n0_known is None:
             n0_known = {}
         if n0_const is not None:
@@ -72,6 +85,9 @@ class RefractiveIndex(object):
         elif n0_smcoeffs is not None:
             self.__data = n0_smcoeffs
             self.get_rix = self.__from_sellmeier
+        elif n0_func is not None:
+            self.__data = n0_func
+            self.get_rix = self.__from_function
         else:
             raise ValueError('n0 all None is not possible!')
         self.n0_known = n0_known
@@ -102,7 +118,14 @@ class RefractiveIndex(object):
             B2 * wls ** 2 / (wls ** 2 - C2) +
             B3 * wls ** 2 / (wls ** 2 - C3)
         ) * numpy.ones_like(wls)
-
+    
+    def __from_function(self, wls):
+        wls = numpy.atleast_1d(wls)
+        if wls.size == 1:
+            if wls.item() in self.n0_known:
+                return numpy.atleast_1d([self.n0_known[wls.item()]])
+        return  self.__data( wls )
+    
     def __call__(self, wls):
         return self.get_rix(wls)
 

--- a/EMpy/materials.py
+++ b/EMpy/materials.py
@@ -33,10 +33,29 @@ class RefractiveIndex(object):
     """Refractive Index.
 
     Unaware of temperature.
+    
+    Parameters
+    ----------
+    Provide ONE of the following named-arguments:
+    
+    n0_const : float
+        A single-value of refractive index, to be used regardless of the wavelength requested.
+        Eg. n0_const = 1.448 for SiO2
+        
+    n0_poly : list/tuple
+        For polynomial rix dispersion function: provide the polynomial coefficients to be evaluated by numpy.polyval.  
+         Eg. `n0_poly = (9,5,3,1)` sets the refractive index function as n = 9(wl**3) + 5(wl**2) + 3(wl) + 1
+    
+    n0_smcoeffs (Sellmeier coefficients): 6-element list/tuple
+        Set the rix dispersion function to the 6-parameter Sellmeier function as so:
+            n =  1. +
+            B1 * wls ** 2 / (wls ** 2 - C1) +
+            B2 * wls ** 2 / (wls ** 2 - C2) +
+            B3 * wls ** 2 / (wls ** 2 - C3)
+        Eg. `n0_smcoeffs=[B1, B2, B3, C1, C2, C3]`; six values total
 
-    Note:
-
-    n0_known only used if RefractiveIndex is evaluated at a single wls.
+    n0_known is only used if RefractiveIndex is evaluated at a single wls.
+        Retrieved as RefractiveIndex.n0_known
 
     """
 

--- a/EMpy/materials.py
+++ b/EMpy/materials.py
@@ -57,12 +57,12 @@ class RefractiveIndex(object):
     n0_func : function
         Provide an arbitrary function to return the refractive index versus wavelength.
         Eg. 
-            >>> SiN_rix = RefractiveIndex(   n0_func = lambda wl: 1.887 + 0.01929/x**2 + 1.6662e-4/x**4   )
-        or
             >>> def SiN_func(wl):
             >>>     x = wl * 1e6    # convert to microns
             >>>     return   1.887 + 0.01929/x**2 + 1.6662e-4/x**4  # cauchy func
             >>> SiN_rix = RefractiveIndex( n0_func = SiN_func )
+        or
+            >>> SiN_rix = RefractiveIndex(   n0_func = lambda wl: 1.887 + 0.01929/(wl*1e6)**2 + 1.6662e-4/(wl*1e6)**4   )
         
     
     n0_known : dictionary


### PR DESCRIPTION
`RefractiveIndex.__init__()` has New option `n0_func=` for user to provide an arbitrary function for rix dispersion function.
Eg. 

    RefractiveIndex( n0_func = lambda wl: 1.448 + 0.01/wl**2 + 2e-4/wl**4 )

or

    def SiO_Cauchy:
        return    1.448 + 0.01/wl**2 + 2e-4/wl**4    # Cauchy model

    RefractiveIndex( n0_func = SiO_Cauchy )

Confirmed this works with the `ex_transfer_matrix.py` example
[ex_transfer_matrix - RIX_func v1.py.zip](https://github.com/lbolla/EMpy/files/75876/ex_transfer_matrix.-.RIX_func.v1.py.zip)

.