### PR TITLE
Tests for `materials.RefractiveIndex` + update to `RefractiveIndex.__from_func()`

### DIFF
--- a/EMpy/materials.py
+++ b/EMpy/materials.py
@@ -53,7 +53,7 @@ class RefractiveIndex(object):
     n0_smcoeffs (Sellmeier coefficients): 6-element list/tuple
         Set the rix dispersion function to the 6-parameter Sellmeier
         function as so:
-            n =  1. +
+            n(wls) =  1. +
             B1 * wls ** 2 / (wls ** 2 - C1) +
             B2 * wls ** 2 / (wls ** 2 - C2) +
             B3 * wls ** 2 / (wls ** 2 - C3)
@@ -61,7 +61,7 @@ class RefractiveIndex(object):
 
     n0_func : function
         Provide an arbitrary function to return the refractive index
-        versus wavelength.
+        versus wavelength.  
         E.g.:
             >>> def SiN_func(wl):
             >>>     x = wl * 1e6 # convert to microns
@@ -71,6 +71,8 @@ class RefractiveIndex(object):
             >>> SiN_rix = RefractiveIndex(
                     n0_func=lambda wl: 1.887 + 0.01929/(wl*1e6)**2 +
                                        1.6662e-4/(wl*1e6)**4)
+        Your function should return a `numpy.array`, since it will be passed a `numpy.array` of the wavelengths requested.  This conversion to `array` happens automatically if your function does math on the wavelength.  If you want to return a constant, include the wavelength like so:
+            >>> rix_func = lambda wl:  0*wl + 1.448     # always returns 1.448
 
     n0_known : dictionary
         Use if RefractiveIndex will only evaluated at a specific set of `wls`.
@@ -131,7 +133,7 @@ class RefractiveIndex(object):
         if wls.size == 1:
             if wls.item() in self.n0_known:
                 return numpy.atleast_1d([self.n0_known[wls.item()]])
-        return self.__data(wls)
+        return self.__data( numpy.ones_like(wls) )
 
     def __call__(self, wls):
         return self.get_rix(wls)

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -1,0 +1,56 @@
+# pylint: disable=no-self-use
+from unittest import TestCase
+
+import random
+import math
+
+from numpy import array
+from numpy import pi
+from numpy.testing import assert_almost_equal
+
+import EMpy.materials as mat
+
+
+class MaterialsTest(TestCase):
+
+    def test_RefractiveIndex(self):
+        ''':: testing the EMpy.materials.RefractiveIndex class constructors'''
+        
+        # test const:
+        test_rix = 1.50
+        a = mat.RefractiveIndex( n0_const = test_rix )
+        self.assertEqual(  a.get_rix(1.0)[0]  ,  array([ test_rix ])  )
+        
+        # test poly:
+        test_poly = [1,1]   # n(wl) = 1*wl + 1
+        test_rix = 2.0      # n(1) = 1*1 + 1 = 2
+        a = mat.RefractiveIndex( n0_poly = test_poly )
+        assert_almost_equal(  a.get_rix(1.0)[0]  ,  array([ test_rix ])  )
+        
+        # test smcoeffs:
+        test_poly = [1]*6   
+        ''' 6-coeffs:
+            n(wls) =  1. +
+            B1 * wls ** 2 / (wls ** 2 - C1) +
+            B2 * wls ** 2 / (wls ** 2 - C2) +
+            B3 * wls ** 2 / (wls ** 2 - C3)
+        '''
+        test_rix = 1.0536712127723509e-08
+        a = mat.RefractiveIndex( n0_smcoeffs = test_poly )
+        assert_almost_equal(  a.get_rix(0.5)[0]  ,  array([ test_rix ])  )
+        
+        # test func:
+        test_rix = 1.50
+        test_poly = lambda x: 0.0*x + test_rix      # returns a constant
+        a = mat.RefractiveIndex( n0_func = test_poly )
+        assert_almost_equal(  a.get_rix([1.0,1.5])[0]  ,  array([ test_rix ])  )
+        
+        # test known:
+        test_rix = 1.50
+        test_wl = 1.0
+        test_dict = {}
+        test_dict[test_wl] = test_rix
+        self.assertEqual(  a.get_rix(test_wl)[0]  , array([ test_rix ])  )
+        
+    #end test_RefractiveIndex()
+#end class(MaterialsTest)


### PR DESCRIPTION
Added tests for each argument type of `RefractiveIndex` class, in the file `materials_test.py`: all tests passed upon running `python3.5 setup.py test`.

In the process, realized that `__from_func()` doesn't return an `np.array`, as all the other funcs do (proving the utility of writing such tests!), so updated `RefractiveIndex.__from_func()` to convert `wls` to an `np.array`.