### PR TITLE
Update FD reference and included DOI

### DIFF
--- a/EMpy/modesolvers/FD.py
+++ b/EMpy/modesolvers/FD.py
@@ -4,7 +4,8 @@
 # pylint: disable=arguments-differ,too-many-arguments
 """Finite Difference Modesolver.
 
-@see: Fallahkhair, "Vector Finite Difference Modesolver for Anisotropic Dielectric Waveguides", JLT 2007 <http://www.photonics.umd.edu/pubs/journal-articles/JA-D/anisotropic-modesolver.pdf>}
+@see: Fallahkhair, "Vector Finite Difference Modesolver for Anisotropic Dielectric Waveguides", JLT 2007 <http://www.photonics.umd.edu/wp-content/uploads/pubs/ja-20/Fallahkhair_JLT_26_1423_2008.pdf>}
+@see: DOI of above reference <http://doi.org/10.1109/JLT.2008.923643>
 @see: http://www.mathworks.com/matlabcentral/fileexchange/loadFile.do?objectId=12734&objectType=FILE
 
 """


### PR DESCRIPTION
I noticed that our reference for the "Vector Finite Difference Modesolver for Anisotropic Dielectric Waveguides" paper (at photonics.umd.edu) had changed. So, I updated it.

Also, I included the DOI for the paper so that people can look at the journal webpage if they wish. I wasn't quite sure how to include the additional link for the paper, but I took a guess at it.