### PR TITLE
two additional examples with simplified parameter input and Stokes polarisation parameter determination

### DIFF
--- a/examples/ex_modesolver_dch.py
+++ b/examples/ex_modesolver_dch.py
@@ -1,0 +1,200 @@
+"""Fully vectorial finite-difference mode solver example.
+
+Flexible mode solver example for fundamental TE & TM modes
+by David Hutchings, School of Engineering, University of Glasgow
+David.Hutchings@glasgow.ac.uk
+"""
+
+import numpy
+import EMpy 
+import matplotlib.pyplot as plt
+from matplotlib import ticker
+
+"""Define cross-section geometry of simulation
+each rectangular element tuple contains
+("label",refractive index,xmin,ymin,xmax,ymax)
+first element tuple defines simulation extent
+units should match units of wavelength wl
+"""
+geom = (("base",1.0,-0.8,-0.8,0.8,1.0),
+        ("substrate",1.5,-0.8,-0.8,0.8,0.0),
+        ("core",3.4,-0.30,0.0,0.30,0.34))
+
+wl = 1.55
+nx, ny = 81, 91
+
+def epsfunc(x_, y_):
+    """Return a matrix describing a 2d material.
+
+    :param x_: x values
+    :param y_: y values
+    :return: 2d-matrix
+    """
+    #xx, yy = numpy.meshgrid(x_, y_)
+    working = geom[0][1]**2*numpy.ones((x_.size,y_.size))
+    for i in range(1,len(geom)):
+        ixmin = numpy.searchsorted(x_,geom[i][2],side='left')
+        iymin = numpy.searchsorted(y_,geom[i][3],side='left')
+        ixmax = numpy.searchsorted(x_,geom[i][4],side='right')
+        iymax = numpy.searchsorted(y_,geom[i][5],side='right') 
+        working[ixmin:ixmax,iymin:iymax] = geom[i][1]**2
+    
+    return working
+
+x = numpy.linspace(geom[0][2], geom[0][4], nx)
+y = numpy.linspace(geom[0][3], geom[0][5], ny)
+
+neigs = 2
+tol = 1e-6
+boundary = '0000'
+
+solver = EMpy.modesolvers.FD.VFDModeSolver(wl, x, y, epsfunc, boundary).solve(
+    neigs, tol)
+
+levls = numpy.geomspace(1./32.,1.,num=11)
+xe = x[:-1]+0.5*(x[1]-x[0])
+ye = y[:-1]+0.5*(y[1]-y[0])
+
+print(solver.modes[0].neff)
+fmax=abs(solver.modes[0].Ex).max()
+fig = plt.figure()
+ax = fig.add_subplot(2, 3, 1)
+plt.contour(xe,ye,abs(solver.modes[0].Ex.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Ex')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 2)
+plt.contour(xe,ye,abs(solver.modes[0].Ey.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Ey')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 3)
+plt.contour(xe,ye,abs(solver.modes[0].Ez.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Ez')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+fmax=abs(solver.modes[0].Hy).max()
+ax = fig.add_subplot(2, 3, 4)
+plt.contour(x,y,abs(solver.modes[0].Hx.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Hx')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 5)
+plt.contour(x,y,abs(solver.modes[0].Hy.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Hy')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 6)
+plt.contour(x,y,abs(solver.modes[0].Hz.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Hz')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+plt.show()
+
+print(solver.modes[1].neff)
+fmax=abs(solver.modes[1].Ey).max()
+fig = plt.figure()
+ax = fig.add_subplot(2, 3, 1)
+plt.contour(xe,ye,abs(solver.modes[1].Ex.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Ex')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 2)
+plt.contour(xe,ye,abs(solver.modes[1].Ey.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Ey')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 3)
+plt.contour(xe,ye,abs(solver.modes[1].Ez.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Ez')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+fmax=abs(solver.modes[1].Hx).max()
+ax = fig.add_subplot(2, 3, 4)
+plt.contour(x,y,abs(solver.modes[1].Hx.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Hx')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 5)
+plt.contour(x,y,abs(solver.modes[1].Hy.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Hy')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+ax = fig.add_subplot(2, 3, 6)
+plt.contour(x,y,abs(solver.modes[1].Hz.T), fmax*levls, 
+            cmap='jet', locator=ticker.LogLocator())
+plt.title('Hz')
+ax.set_xlim(geom[0][2], geom[0][4])
+ax.set_ylim(geom[0][3], geom[0][5])
+for i in range(1,len(geom)):
+    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
+    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
+    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+plt.show()

--- a/examples/ex_modesolver_dch.py
+++ b/examples/ex_modesolver_dch.py
@@ -12,13 +12,13 @@ from matplotlib import ticker
 
 """Define cross-section geometry of simulation
 each rectangular element tuple contains
-("label",refractive index,xmin,ymin,xmax,ymax)
+("label",xmin,ymin,xmax,ymax,refractive index)
 first element tuple defines simulation extent
 units should match units of wavelength wl
 """
-geom = (("base",1.0,-0.8,-0.8,0.8,1.0),
-        ("substrate",1.5,-0.8,-0.8,0.8,0.0),
-        ("core",3.4,-0.30,0.0,0.30,0.34))
+geom = (("base",-0.8,-0.8,0.8,1.0,1.0),
+        ("substrate",-0.8,-0.8,0.8,0.0,1.5),
+        ("core",-0.30,0.0,0.30,0.34,3.4))
 
 wl = 1.55
 nx, ny = 81, 91
@@ -31,18 +31,18 @@ def epsfunc(x_, y_):
     :return: 2d-matrix
     """
     #xx, yy = numpy.meshgrid(x_, y_)
-    working = geom[0][1]**2*numpy.ones((x_.size,y_.size))
+    working = geom[0][5]**2*numpy.ones((x_.size,y_.size))
     for i in range(1,len(geom)):
-        ixmin = numpy.searchsorted(x_,geom[i][2],side='left')
-        iymin = numpy.searchsorted(y_,geom[i][3],side='left')
-        ixmax = numpy.searchsorted(x_,geom[i][4],side='right')
-        iymax = numpy.searchsorted(y_,geom[i][5],side='right') 
-        working[ixmin:ixmax,iymin:iymax] = geom[i][1]**2
+        ixmin = numpy.searchsorted(x_,geom[i][1],side='left')
+        iymin = numpy.searchsorted(y_,geom[i][2],side='left')
+        ixmax = numpy.searchsorted(x_,geom[i][3],side='right')
+        iymax = numpy.searchsorted(y_,geom[i][4],side='right') 
+        working[ixmin:ixmax,iymin:iymax] = geom[i][5]**2
     
     return working
 
-x = numpy.linspace(geom[0][2], geom[0][4], nx)
-y = numpy.linspace(geom[0][3], geom[0][5], ny)
+x = numpy.linspace(geom[0][1], geom[0][3], nx)
+y = numpy.linspace(geom[0][2], geom[0][4], ny)
 
 neigs = 2
 tol = 1e-6
@@ -62,69 +62,69 @@ ax = fig.add_subplot(2, 3, 1)
 plt.contour(xe,ye,abs(solver.modes[0].Ex.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Ex')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 2)
 plt.contour(xe,ye,abs(solver.modes[0].Ey.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Ey')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 3)
 plt.contour(xe,ye,abs(solver.modes[0].Ez.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Ez')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 fmax=abs(solver.modes[0].Hy).max()
 ax = fig.add_subplot(2, 3, 4)
 plt.contour(x,y,abs(solver.modes[0].Hx.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Hx')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 5)
 plt.contour(x,y,abs(solver.modes[0].Hy.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Hy')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 6)
 plt.contour(x,y,abs(solver.modes[0].Hz.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Hz')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 plt.show()
 
 print(solver.modes[1].neff)
@@ -134,67 +134,67 @@ ax = fig.add_subplot(2, 3, 1)
 plt.contour(xe,ye,abs(solver.modes[1].Ex.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Ex')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 2)
 plt.contour(xe,ye,abs(solver.modes[1].Ey.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Ey')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 3)
 plt.contour(xe,ye,abs(solver.modes[1].Ez.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Ez')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 fmax=abs(solver.modes[1].Hx).max()
 ax = fig.add_subplot(2, 3, 4)
 plt.contour(x,y,abs(solver.modes[1].Hx.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Hx')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 5)
 plt.contour(x,y,abs(solver.modes[1].Hy.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Hy')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 ax = fig.add_subplot(2, 3, 6)
 plt.contour(x,y,abs(solver.modes[1].Hz.T), fmax*levls, 
             cmap='jet', locator=ticker.LogLocator())
 plt.title('Hz')
-ax.set_xlim(geom[0][2], geom[0][4])
-ax.set_ylim(geom[0][3], geom[0][5])
+ax.set_xlim(geom[0][1], geom[0][3])
+ax.set_ylim(geom[0][2], geom[0][4])
 for i in range(1,len(geom)):
-    plt.hlines(geom[i][3],geom[i][2],geom[i][4])
-    plt.hlines(geom[i][5],geom[i][2],geom[i][4])
-    plt.vlines(geom[i][2],geom[i][3],geom[i][5])
-    plt.vlines(geom[i][4],geom[i][3],geom[i][5])
+    plt.hlines(geom[i][2],geom[i][1],geom[i][3])
+    plt.hlines(geom[i][4],geom[i][1],geom[i][3])
+    plt.vlines(geom[i][1],geom[i][2],geom[i][4])
+    plt.vlines(geom[i][3],geom[i][2],geom[i][4])
 plt.show()

--- a/examples/ex_modesolver_dch_anis.py
+++ b/examples/ex_modesolver_dch_anis.py
@@ -18,12 +18,14 @@ each rectangular element tuple contains
 first element tuple defines simulation extent
 units should match units of wavelength wl
 """
-geom = (("base",-0.6,-0.6,0.6,0.8,1.44**2),
+geom = (("base",-0.7,-0.5,0.7,0.9,1.44**2),
         ("core",-0.35,0.0,0.35,0.34,3.48**2),
-        ("clad",-0.35,0.34,0.35,0.44,2.19**2,-0.1j,0.1j,2.19**2,2.19**2))
+        ("clad",-0.35,0.34,0.35,0.44,2.19**2,-0.006j,0.006j,2.19**2,2.19**2),
+        ("slot",-0.05,0.00,0.05,0.34,2.19**2,-0.006j,0.006j,2.19**2,2.19**2))
+#clad corresponds to Ce:TbIG with -3200deg/cm
 
 wl = 1.55
-nx, ny = 121, 141
+nx, ny = 141, 141
 
 def epsfunc(x_, y_):
     """Return a matrix describing a 2d material.
@@ -32,7 +34,7 @@ def epsfunc(x_, y_):
     :param y_: y values
     :return: 2d-matrix *5
     """
-#assume base medium isisotropic
+#assume base medium is isotropic
     working = numpy.zeros((x_.size,y_.size,5),dtype='complex')
     working[:,:,0] = geom[0][5]*numpy.ones((x_.size,y_.size))
     working[:,:,3] = geom[0][5]*numpy.ones((x_.size,y_.size))


### PR DESCRIPTION
examples/ex_modesolver_dch.py 
Additional example for the finite difference mode solver for isotropic media

parameter input is simplified with rectangular regions defined in the geom tuple


examples/ex_modesolver_dch_anis.py 
Additional example for the finite difference mode solver for anisotropic media.

parameter input is simplified with rectangular regions defined in the geom tuple

mode profile is also plotted in terms of position Stokes parameters, and the average Stokes parameter values are determined. This aids the analysis of polarisation dependencies.